### PR TITLE
Add unit tests for MultiBannerLoader and MultiInterstitialAdLoader (#…

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/multiadloader/MultiBannerLoaderTest.kt
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/multiadloader/MultiBannerLoaderTest.kt
@@ -1,0 +1,375 @@
+package org.prebid.mobile.api.multiadloader
+
+import android.app.Activity
+import android.content.Context
+import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.admanager.AdManagerAdView
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mock
+import org.mockito.MockedConstruction
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.MockitoAnnotations
+import org.prebid.mobile.AdSize
+import org.prebid.mobile.api.data.SdkType
+import org.prebid.mobile.api.exceptions.AdException
+import org.prebid.mobile.api.multiadloader.listeners.MultiBannerViewListener
+import org.prebid.mobile.api.rendering.BannerView
+import org.prebid.mobile.api.rendering.listeners.BannerViewListener
+import org.prebid.mobile.configuration.SdkConfigHolder
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class MultiBannerLoaderTest {
+
+    @Mock
+    private lateinit var mockListener: MultiBannerViewListener
+
+    private lateinit var context: Context
+    private lateinit var adSize: AdSize
+
+    private lateinit var bannerConstruction: MockedConstruction<BannerView>
+    private lateinit var gamViewConstruction: MockedConstruction<AdManagerAdView>
+
+    private val configId = "test-config-id"
+    private val gamAdUnitId = "/1234/test-gam-ad-unit"
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        context = Robolectric.buildActivity(Activity::class.java).create().get()
+        adSize = AdSize(300, 250)
+        bannerConstruction = Mockito.mockConstruction(BannerView::class.java)
+        gamViewConstruction = Mockito.mockConstruction(AdManagerAdView::class.java)
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.PREBID, SdkType.GAM)
+    }
+
+    @After
+    fun tearDown() {
+        bannerConstruction.close()
+        gamViewConstruction.close()
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.PREBID, SdkType.GAM)
+    }
+
+    private fun createLoader(
+        size: AdSize? = adSize,
+        cfg: String? = configId,
+        gamId: String? = gamAdUnitId,
+    ): MultiBannerLoader {
+        val loader = MultiBannerLoader(context, size, cfg, gamId)
+        loader.setListener(mockListener)
+        return loader
+    }
+
+    private fun capturePrebidListener(instanceIndex: Int = 0): BannerViewListener {
+        val banner = bannerConstruction.constructed()[instanceIndex]
+        val captor = ArgumentCaptor.forClass(BannerViewListener::class.java)
+        verify(banner).setBannerListener(captor.capture())
+        return captor.value
+    }
+
+    private fun captureGamListener(instanceIndex: Int = 0): AdListener {
+        val gamView = gamViewConstruction.constructed()[instanceIndex]
+        val captor = ArgumentCaptor.forClass(AdListener::class.java)
+        verify(gamView).adListener = captor.capture()
+        return captor.value
+    }
+
+    // 1. loadAd builds both inner SDK loaders when priority is default and inputs valid
+    @Test
+    fun loadAd_prebidFirstPriority_constructsBothSdkLoaders() {
+        val loader = createLoader()
+
+        loader.loadAd()
+
+        assertEquals(1, bannerConstruction.constructed().size)
+        assertEquals(1, gamViewConstruction.constructed().size)
+
+        val banner = bannerConstruction.constructed()[0]
+        verify(banner).setBannerListener(any())
+        verify(banner).setAutoRefreshDelay(anyInt())
+        verify(banner).loadAd()
+
+        val gamView = gamViewConstruction.constructed()[0]
+        verify(gamView).adUnitId = gamAdUnitId
+        verify(gamView).setAdSizes(any())
+        verify(gamView).adListener = any()
+        verify(gamView).loadAd(any())
+    }
+
+    // 2. configId=null → Prebid reports failure immediately and never constructs BannerView
+    @Test
+    fun loadAd_configIdNull_prebidFailsImmediatelyWithoutConstructingBannerView() {
+        val loader = createLoader(cfg = null)
+
+        loader.loadAd()
+
+        assertEquals(0, bannerConstruction.constructed().size)
+        verify(mockListener).onAdFailed(isNull(), eq("ConfigId is empty"), eq(SdkType.PREBID))
+    }
+
+    // 3. gamAdUnitId=null → GAM reports failure immediately and never constructs AdManagerAdView
+    @Test
+    fun loadAd_gamAdUnitIdNull_gamFailsImmediatelyWithoutConstructingAdView() {
+        val loader = createLoader(gamId = null)
+
+        loader.loadAd()
+
+        assertEquals(0, gamViewConstruction.constructed().size)
+        verify(mockListener).onAdFailed(isNull(), eq("GAM AdUnitId is empty"), eq(SdkType.GAM))
+    }
+
+    // 4. adSize=null with GAM id present → GAM fails with "GAM adSize is null"
+    @Test
+    fun loadAd_adSizeNull_gamFailsWithAdSizeNullMessage() {
+        val loader = createLoader(size = null)
+
+        loader.loadAd()
+
+        assertEquals(0, gamViewConstruction.constructed().size)
+        verify(mockListener).onAdFailed(isNull(), eq("GAM adSize is null"), eq(SdkType.GAM))
+    }
+
+    // 5. Prebid is priority head and loads → listener notified once and GAM is destroyed (cancelOtherRequests)
+    @Test
+    fun prebidLoadedFirst_prebidIsFirstPriority_notifiesListenerAndCancelsGam() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val banner = bannerConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+
+        prebidListener.onAdLoaded(banner)
+
+        verify(mockListener, times(1)).onAdLoaded(banner, SdkType.PREBID)
+        val gamView = gamViewConstruction.constructed()[0]
+        verify(gamView).destroy()
+    }
+
+    // 6. GAM loads while Prebid is still priority head → listener NOT notified (GAM held back)
+    @Test
+    fun gamLoadedButPrebidFirstPriority_listenerNotNotified() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamListener = captureGamListener()
+        gamListener.onAdLoaded()
+
+        verifyNoInteractions(mockListener)
+    }
+
+    // 7. Prebid fails → removed from priority → GAM succeeds afterwards → listener notified with GAM
+    @Test
+    fun prebidFails_thenGamSucceeds_gamSelectedAfterPriorityShift() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdFailed(null, AdException(AdException.INTERNAL_ERROR, "prebid error"))
+
+        val gamView = gamViewConstruction.constructed()[0]
+        val gamListener = captureGamListener()
+        gamListener.onAdLoaded()
+
+        verify(mockListener).onAdLoaded(gamView, SdkType.GAM)
+    }
+
+    // 8. Prebid fails → listener receives onAdFailed with PREBID and the exception message
+    @Test
+    fun prebidFails_listenerReceivesOnAdFailed() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidListener = capturePrebidListener()
+        val ex = AdException(AdException.INTERNAL_ERROR, "prebid error")
+        prebidListener.onAdFailed(null, ex)
+
+        verify(mockListener).onAdFailed(
+            isNull(), eq(ex.message), eq(SdkType.PREBID)
+        )
+    }
+
+    // 9. Custom priority [GAM, PREBID] → GAM loads → listener notified with GAM
+    @Test
+    fun customPriorityOrder_gamFirst_gamWinsImmediately() {
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.GAM, SdkType.PREBID)
+
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamView = gamViewConstruction.constructed()[0]
+        val gamListener = captureGamListener()
+        gamListener.onAdLoaded()
+
+        verify(mockListener).onAdLoaded(gamView, SdkType.GAM)
+        val banner = bannerConstruction.constructed()[0]
+        verify(banner).destroy()
+    }
+
+    // 10. destroy() after loadAd destroys both inner loaders
+    @Test
+    fun destroy_destroysBothInnerLoaders() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val banner = bannerConstruction.constructed()[0]
+        val gamView = gamViewConstruction.constructed()[0]
+
+        loader.destroy()
+
+        verify(banner).destroy()
+        verify(gamView).destroy()
+    }
+
+    // 11. loadAd called twice destroys previous instances before creating new ones
+    @Test
+    fun loadAdCalledTwice_destroysPreviousResourcesFirst() {
+        val loader = createLoader()
+
+        loader.loadAd()
+        val firstBanner = bannerConstruction.constructed()[0]
+        val firstGamView = gamViewConstruction.constructed()[0]
+
+        loader.loadAd()
+
+        verify(firstBanner).destroy()
+        verify(firstGamView).destroy()
+        assertEquals(2, bannerConstruction.constructed().size)
+        assertEquals(2, gamViewConstruction.constructed().size)
+    }
+
+    // 12. Duplicate Prebid onAdLoaded callbacks only notify listener once (isAdLoaded guard)
+    @Test
+    fun prebidOnAdLoaded_calledTwice_listenerNotifiedOnce() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val banner = bannerConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+
+        prebidListener.onAdLoaded(banner)
+        prebidListener.onAdLoaded(banner)
+
+        verify(mockListener, times(1)).onAdLoaded(banner, SdkType.PREBID)
+    }
+
+    // 13. GAM passthrough callbacks: onAdClicked, onAdImpression, onAdOpened, onAdClosed route to listener
+    @Test
+    fun gamPassthroughCallbacks_routedToMultiBannerViewListener() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamListener = captureGamListener()
+
+        gamListener.onAdClicked()
+        gamListener.onAdImpression()
+        gamListener.onAdOpened()
+        gamListener.onAdClosed()
+
+        verify(mockListener).onAdClicked(null, SdkType.GAM)
+        verify(mockListener).onImpression(SdkType.GAM)
+        verify(mockListener).onAdOpened(SdkType.GAM)
+        verify(mockListener).onAdClosed(null, SdkType.GAM)
+    }
+
+    // 14. Prebid onAdDisplayed only fires listener when selectedSDK == PREBID
+    @Test
+    fun prebidCallback_onAdDisplayed_onlyFiresWhenSelected() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val banner = bannerConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+
+        // selectedSDK is still null here → should be ignored
+        prebidListener.onAdDisplayed(banner)
+        verifyNoInteractions(mockListener)
+
+        // Trigger selection
+        prebidListener.onAdLoaded(banner)
+
+        // Now onAdDisplayed should route
+        prebidListener.onAdDisplayed(banner)
+        verify(mockListener).onAdDisplayed(banner, SdkType.PREBID)
+    }
+
+    // 15. Prebid onAdClicked and onAdClosed route to listener
+    @Test
+    fun prebidCallback_onAdClicked_onAdClosed_routedToListener() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val banner = bannerConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+
+        prebidListener.onAdClicked(banner)
+        prebidListener.onAdClosed(banner)
+
+        verify(mockListener).onAdClicked(banner, SdkType.PREBID)
+        verify(mockListener).onAdClosed(banner, SdkType.PREBID)
+    }
+
+    // Bonus: GAM failure after Prebid already loaded → listener.onAdFailed still fires for GAM
+    @Test
+    fun gamFails_listenerReceivesGamFailure() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamListener = captureGamListener()
+        val loadAdError = mock(LoadAdError::class.java)
+        Mockito.`when`(loadAdError.message).thenReturn("gam error")
+
+        gamListener.onAdFailedToLoad(loadAdError)
+
+        verify(mockListener).onAdFailed(isNull(), eq("gam error"), eq(SdkType.GAM))
+    }
+
+    // Bonus: setListener replaces previous listener
+    @Test
+    fun setListener_replacesPreviousListener() {
+        val loader = createLoader()
+        val newListener = mock(MultiBannerViewListener::class.java)
+        loader.setListener(newListener)
+        loader.loadAd()
+
+        val banner = bannerConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdLoaded(banner)
+
+        verify(newListener).onAdLoaded(banner, SdkType.PREBID)
+        verifyNoInteractions(mockListener)
+    }
+
+    // Bonus: initial priorityOrder snapshot — mutating SdkConfigHolder after construction doesn't affect loader
+    @Test
+    fun priorityOrder_snapshotAtConstructionTime_isIndependentOfLaterMutations() {
+        val loader = createLoader()
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.GAM, SdkType.PREBID)
+
+        loader.loadAd()
+        val banner = bannerConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdLoaded(banner)
+
+        // Prebid should still win because the snapshot taken at construction was [PREBID, GAM]
+        verify(mockListener).onAdLoaded(banner, SdkType.PREBID)
+        assertEquals(1, gamViewConstruction.constructed().size)
+        verify(gamViewConstruction.constructed()[0]).destroy()
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/multiadloader/MultiInterstitialAdLoaderTest.kt
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/multiadloader/MultiInterstitialAdLoaderTest.kt
@@ -1,0 +1,456 @@
+package org.prebid.mobile.api.multiadloader
+
+import android.app.Activity
+import android.content.Context
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.admanager.AdManagerAdRequest
+import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
+import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.ArgumentMatchers.isNull
+import org.mockito.Mock
+import org.mockito.MockedConstruction
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.MockitoAnnotations
+import org.prebid.mobile.api.data.SdkType
+import org.prebid.mobile.api.exceptions.AdException
+import org.prebid.mobile.api.multiadloader.MultiInterstitialAdLoader.SdkState
+import org.prebid.mobile.api.multiadloader.listeners.MultiInterstitialAdListener
+import org.prebid.mobile.api.rendering.InterstitialAdUnit
+import org.prebid.mobile.api.rendering.listeners.InterstitialAdUnitListener
+import org.prebid.mobile.configuration.SdkConfigHolder
+import org.prebid.mobile.test.utils.WhiteBox
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [24])
+class MultiInterstitialAdLoaderTest {
+
+    @Mock
+    private lateinit var mockListener: MultiInterstitialAdListener
+
+    private lateinit var context: Context
+
+    private lateinit var interstitialConstruction: MockedConstruction<InterstitialAdUnit>
+    private lateinit var gamInterstitialStatic: MockedStatic<AdManagerInterstitialAd>
+
+    private val configId = "test-config-id"
+    private val gamAdUnitId = "/1234/test-gam-ad-unit"
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        context = Robolectric.buildActivity(Activity::class.java).create().get()
+        interstitialConstruction = Mockito.mockConstruction(InterstitialAdUnit::class.java)
+        gamInterstitialStatic = Mockito.mockStatic(AdManagerInterstitialAd::class.java)
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.PREBID, SdkType.GAM)
+    }
+
+    @After
+    fun tearDown() {
+        interstitialConstruction.close()
+        gamInterstitialStatic.close()
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.PREBID, SdkType.GAM)
+    }
+
+    private fun createLoader(
+        cfg: String? = configId,
+        gamId: String? = gamAdUnitId,
+    ): MultiInterstitialAdLoader {
+        val loader = MultiInterstitialAdLoader(context, cfg, gamId)
+        loader.setListener(mockListener)
+        return loader
+    }
+
+    private fun capturePrebidListener(instanceIndex: Int = 0): InterstitialAdUnitListener {
+        val unit = interstitialConstruction.constructed()[instanceIndex]
+        val captor = ArgumentCaptor.forClass(InterstitialAdUnitListener::class.java)
+        verify(unit).setInterstitialAdUnitListener(captor.capture())
+        return captor.value
+    }
+
+    private fun captureGamCallback(expectedTimes: Int = 1): AdManagerInterstitialAdLoadCallback {
+        val captor = ArgumentCaptor.forClass(AdManagerInterstitialAdLoadCallback::class.java)
+        gamInterstitialStatic.verify({
+            AdManagerInterstitialAd.load(
+                any(Context::class.java),
+                anyString(),
+                any(AdManagerAdRequest::class.java),
+                captor.capture()
+            )
+        }, times(expectedTimes))
+        return captor.value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun sdkStatesOf(loader: MultiInterstitialAdLoader): Map<SdkType, SdkState> =
+        WhiteBox.getInternalState(loader, "sdkStates") as Map<SdkType, SdkState>
+
+    private fun selectedSdkOf(loader: MultiInterstitialAdLoader): SdkType? =
+        WhiteBox.getInternalState(loader, "selectedSDK") as SdkType?
+
+    // 1. On construction all SDK states are NOT_STARTED
+    @Test
+    fun init_allSdkStatesAreNotStarted() {
+        val loader = createLoader()
+        val states = sdkStatesOf(loader)
+
+        assertEquals(SdkState.NOT_STARTED, states[SdkType.PREBID])
+        assertEquals(SdkState.NOT_STARTED, states[SdkType.GAM])
+        assertNull(selectedSdkOf(loader))
+    }
+
+    // 2. With default priority PREBID-first, both SDKs are loaded; GAM first then PREBID (per loadAd logic)
+    @Test
+    fun loadAd_prebidFirstPriority_loadsGamAndPrebid() {
+        val loader = createLoader()
+
+        loader.loadAd()
+
+        // GAM static load was called
+        gamInterstitialStatic.verify {
+            AdManagerInterstitialAd.load(
+                any(Context::class.java),
+                eq(gamAdUnitId),
+                any(AdManagerAdRequest::class.java),
+                any(AdManagerInterstitialAdLoadCallback::class.java)
+            )
+        }
+        // PREBID was constructed and loadAd invoked
+        assertEquals(1, interstitialConstruction.constructed().size)
+        verify(interstitialConstruction.constructed()[0]).loadAd()
+
+        val states = sdkStatesOf(loader)
+        assertEquals(SdkState.LOADING, states[SdkType.PREBID])
+        assertEquals(SdkState.LOADING, states[SdkType.GAM])
+    }
+
+    // 3. Custom priority [GAM, PREBID] → only GAM loads initially, PREBID held back
+    @Test
+    fun loadAd_gamFirstPriority_prebidNotLoadedInitially() {
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.GAM, SdkType.PREBID)
+
+        val loader = createLoader()
+        loader.loadAd()
+
+        gamInterstitialStatic.verify {
+            AdManagerInterstitialAd.load(
+                any(Context::class.java),
+                eq(gamAdUnitId),
+                any(AdManagerAdRequest::class.java),
+                any(AdManagerInterstitialAdLoadCallback::class.java)
+            )
+        }
+        assertEquals(0, interstitialConstruction.constructed().size)
+
+        val states = sdkStatesOf(loader)
+        assertEquals(SdkState.LOADING, states[SdkType.GAM])
+        assertEquals(SdkState.NOT_STARTED, states[SdkType.PREBID])
+    }
+
+    // 4. configId=null → PREBID fails immediately
+    @Test
+    fun loadAd_configIdNull_prebidFailsWithConfigIdIsEmpty() {
+        val loader = createLoader(cfg = null)
+
+        loader.loadAd()
+
+        assertEquals(0, interstitialConstruction.constructed().size)
+        verify(mockListener).onAdFailed(eq("ConfigId is empty"), eq(SdkType.PREBID))
+        assertEquals(SdkState.FAILED, sdkStatesOf(loader)[SdkType.PREBID])
+    }
+
+    // 5. gamAdUnitId=null → GAM fails immediately
+    @Test
+    fun loadAd_gamAdUnitIdNull_gamFailsWithAdUnitIdIsEmpty() {
+        val loader = createLoader(gamId = null)
+
+        loader.loadAd()
+
+        // GAM.load was not called (null path returns before static call)
+        gamInterstitialStatic.verifyNoInteractions()
+        verify(mockListener).onAdFailed(eq("GAM AdUnitId is empty"), eq(SdkType.GAM))
+        assertEquals(SdkState.FAILED, sdkStatesOf(loader)[SdkType.GAM])
+    }
+
+    // 6. PREBID loads first with default priority → listener notified, GAM gets destroyed and reset
+    @Test
+    fun prebidLoadedFirst_notifiesListenerAndCancelsGam() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdLoaded(interstitialConstruction.constructed()[0])
+
+        verify(mockListener, times(1)).onAdLoaded(SdkType.PREBID)
+        val states = sdkStatesOf(loader)
+        assertEquals(SdkState.LOADED, states[SdkType.PREBID])
+        assertEquals(SdkState.NOT_STARTED, states[SdkType.GAM])
+        assertEquals(SdkType.PREBID, selectedSdkOf(loader))
+    }
+
+    // 7. GAM loads but PREBID is first priority and hasn't responded yet → listener not notified
+    @Test
+    fun gamLoadedButPrebidFirstPriority_listenerNotNotifiedYet() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdLoaded(mock(AdManagerInterstitialAd::class.java))
+
+        verifyNoInteractions(mockListener)
+        val states = sdkStatesOf(loader)
+        assertEquals(SdkState.LOADED, states[SdkType.GAM])
+        assertEquals(SdkState.LOADING, states[SdkType.PREBID])
+        assertNull(selectedSdkOf(loader))
+    }
+
+    // 8. GAM loads, then PREBID fails → GAM becomes first priority and is selected
+    @Test
+    fun gamLoaded_thenPrebidFails_gamBecomesSelected() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdLoaded(mock(AdManagerInterstitialAd::class.java))
+
+        val prebidListener = capturePrebidListener()
+        val prebidException = AdException(AdException.INTERNAL_ERROR, "prebid error")
+        prebidListener.onAdFailed(interstitialConstruction.constructed()[0], prebidException)
+
+        verify(mockListener).onAdLoaded(SdkType.GAM)
+        verify(mockListener).onAdFailed(eq(prebidException.message), eq(SdkType.PREBID))
+        assertEquals(SdkType.GAM, selectedSdkOf(loader))
+    }
+
+    // 9. PREBID fails first, then GAM loads → GAM selected
+    @Test
+    fun prebidFailsFirst_gamLoadsAfter_gamSelected() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdFailed(
+            interstitialConstruction.constructed()[0],
+            AdException(AdException.INTERNAL_ERROR, "prebid error")
+        )
+
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdLoaded(mock(AdManagerInterstitialAd::class.java))
+
+        verify(mockListener).onAdLoaded(SdkType.GAM)
+        verify(interstitialConstruction.constructed()[0]).destroy()
+        assertEquals(SdkType.GAM, selectedSdkOf(loader))
+    }
+
+    // 10. Both SDKs fail → onAdLoaded never fires, onAdFailed fires for each
+    @Test
+    fun bothSdksFail_noOnAdLoadedEverCalled() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidListener = capturePrebidListener()
+        val prebidException = AdException(AdException.INTERNAL_ERROR, "prebid error")
+        prebidListener.onAdFailed(interstitialConstruction.constructed()[0], prebidException)
+
+        val gamLoadAdError = mock(LoadAdError::class.java)
+        Mockito.`when`(gamLoadAdError.message).thenReturn("gam error")
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdFailedToLoad(gamLoadAdError)
+
+        verify(mockListener, never()).onAdLoaded(SdkType.PREBID)
+        verify(mockListener, never()).onAdLoaded(SdkType.GAM)
+        verify(mockListener).onAdFailed(eq(prebidException.message), eq(SdkType.PREBID))
+        verify(mockListener).onAdFailed(eq("gam error"), eq(SdkType.GAM))
+        assertNull(selectedSdkOf(loader))
+    }
+
+    // 11. showAd() with no selected ad → onAdFailedToShow fires
+    @Test
+    fun showAd_noSelectedSdk_callsOnAdFailedToShow() {
+        val loader = createLoader()
+
+        loader.showAd()
+
+        verify(mockListener).onAdFailedToShow(eq("No loaded interstitial ad to show"), isNull())
+    }
+
+    // 12. showAd() with PREBID selected → delegates to PrebidAdLoader.show() which calls interstitial.show()
+    @Test
+    fun showAd_prebidSelected_delegatesToPrebidShow() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidUnit = interstitialConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdLoaded(prebidUnit)
+
+        loader.showAd()
+
+        verify(prebidUnit).show()
+    }
+
+    // 13. showAd() with GAM selected → delegates to GamAdLoader.show() which calls interstitialAd.show(activity)
+    @Test
+    fun showAd_gamSelected_delegatesToGamShowWithActivity() {
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.GAM, SdkType.PREBID)
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamAd = mock(AdManagerInterstitialAd::class.java)
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdLoaded(gamAd)
+
+        loader.showAd()
+
+        verify(gamAd).show(any(Activity::class.java))
+    }
+
+    // 14. destroy() resets all states to NOT_STARTED and destroys inner loaders
+    @Test
+    fun destroy_resetsAllStatesToNotStarted() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidUnit = interstitialConstruction.constructed()[0]
+
+        loader.destroy()
+
+        verify(prebidUnit).destroy()
+        val states = sdkStatesOf(loader)
+        assertEquals(SdkState.NOT_STARTED, states[SdkType.PREBID])
+        assertEquals(SdkState.NOT_STARTED, states[SdkType.GAM])
+    }
+
+    // 15. maybeLoadPrebid: custom priority [GAM, PREBID] → GAM fails → PREBID gets loaded lazily
+    @Test
+    fun maybeLoadPrebid_gamFirstAndFails_triggersPrebidLoad() {
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.GAM, SdkType.PREBID)
+
+        val loader = createLoader()
+        loader.loadAd()
+
+        // Initially Prebid is not loaded
+        assertEquals(0, interstitialConstruction.constructed().size)
+
+        // GAM fails
+        val gamLoadAdError = mock(LoadAdError::class.java)
+        Mockito.`when`(gamLoadAdError.message).thenReturn("gam error")
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdFailedToLoad(gamLoadAdError)
+
+        // Now Prebid should have been constructed lazily via maybeLoadPrebid
+        assertEquals(1, interstitialConstruction.constructed().size)
+        verify(interstitialConstruction.constructed()[0]).loadAd()
+        assertEquals(SdkState.LOADING, sdkStatesOf(loader)[SdkType.PREBID])
+    }
+
+    // 16. maybeLoadPrebid: priority without PREBID → GAM fails → PREBID never constructed
+    @Test
+    fun maybeLoadPrebid_prebidNotInPriority_doesNotLoad() {
+        SdkConfigHolder.priorityOrderSDK = listOf(SdkType.GAM)
+
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamLoadAdError = mock(LoadAdError::class.java)
+        Mockito.`when`(gamLoadAdError.message).thenReturn("gam error")
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdFailedToLoad(gamLoadAdError)
+
+        assertEquals(0, interstitialConstruction.constructed().size)
+    }
+
+    // 17. Prebid passthrough callbacks: onAdDisplayed, onAdClicked, onAdClosed route to listener
+    @Test
+    fun prebidCallbacks_passThrough_onAdDisplayed_onAdClicked_onAdClosed() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidUnit = interstitialConstruction.constructed()[0]
+        val prebidListener = capturePrebidListener()
+
+        prebidListener.onAdDisplayed(prebidUnit)
+        prebidListener.onAdClicked(prebidUnit)
+        prebidListener.onAdClosed(prebidUnit)
+
+        verify(mockListener).onAdDisplayed(SdkType.PREBID)
+        verify(mockListener).onAdClicked(SdkType.PREBID)
+        verify(mockListener).onAdClosed(SdkType.PREBID)
+    }
+
+    // 18. GAM onAdFailedToLoad → listener receives error with GAM SdkType
+    @Test
+    fun gamOnAdFailedToLoad_listenerReceivesError() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val gamLoadAdError = mock(LoadAdError::class.java)
+        Mockito.`when`(gamLoadAdError.message).thenReturn("gam specific error")
+
+        val gamCallback = captureGamCallback()
+        gamCallback.onAdFailedToLoad(gamLoadAdError)
+
+        verify(mockListener).onAdFailed(eq("gam specific error"), eq(SdkType.GAM))
+        assertEquals(SdkState.FAILED, sdkStatesOf(loader)[SdkType.GAM])
+    }
+
+    // Bonus: loadAd called twice → previous resources destroyed first, states reset
+    @Test
+    fun loadAdCalledTwice_destroysPreviousPrebidInstance() {
+        val loader = createLoader()
+
+        loader.loadAd()
+        val firstPrebid = interstitialConstruction.constructed()[0]
+
+        loader.loadAd()
+
+        verify(firstPrebid).destroy()
+        assertEquals(2, interstitialConstruction.constructed().size)
+    }
+
+    // Bonus: setListener replaces a previous one
+    @Test
+    fun setListener_replacesPreviousListener() {
+        val loader = createLoader()
+        val newListener = mock(MultiInterstitialAdListener::class.java)
+        loader.setListener(newListener)
+
+        loader.loadAd()
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdLoaded(interstitialConstruction.constructed()[0])
+
+        verify(newListener).onAdLoaded(SdkType.PREBID)
+        verifyNoInteractions(mockListener)
+    }
+
+    // Bonus: Prebid onAdFailed with null exception message gets "Unknown error"
+    @Test
+    fun prebidOnAdFailed_nullException_listenerReceivesUnknownError() {
+        val loader = createLoader()
+        loader.loadAd()
+
+        val prebidListener = capturePrebidListener()
+        prebidListener.onAdFailed(interstitialConstruction.constructed()[0], null)
+
+        verify(mockListener).onAdFailed(eq("Unknown error"), eq(SdkType.PREBID))
+        assertEquals(SdkState.FAILED, sdkStatesOf(loader)[SdkType.PREBID])
+    }
+}


### PR DESCRIPTION
…925)

* feat: add comprehensive unit tests for `MultiBannerLoader`
* feat: add comprehensive unit tests for `MultiInterstitialAdLoader`
* test: verify SDK priority handling, error reporting, and lifecycle management for multi-ad loaders